### PR TITLE
Remove meeting location override for all Redwood City locations

### DIFF
--- a/cal.py
+++ b/cal.py
@@ -62,8 +62,6 @@ for e in meetings:
 		location = "Virtual"
 	if location.lower() == "n/a":
 		location = ""
-	if ("Redwood City" in location):
-		location = "455 County Center, Room 101, Redwood City, CA 94063"
 	page_contents["meetings"].append({
 		"title": e.name,
 		"date": e.begin.to(TZ).format('MMM D'),


### PR DESCRIPTION
### What?
Remove the hardcoded meeting location override for all location strings containing 'Redwood City'.

### Why?
The previous override behavior causes other meeting locations within Redwood City to be overwritten. This is especially problematic since our new usual meeting location is not the hardcoded one.